### PR TITLE
feat: 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.flywaydb:flyway-core:11.1.1'
     implementation 'org.flywaydb:flyway-mysql:11.1.1'
+
+    def querydslVersion = "5.0.0"
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/org/signaling/signaling_server/common/type/success/AuthSuccessType.java
+++ b/src/main/java/org/signaling/signaling_server/common/type/success/AuthSuccessType.java
@@ -2,7 +2,7 @@ package org.signaling.signaling_server.common.type.success;
 
 public enum AuthSuccessType implements SuccessTypeCode {
     SIGN_UP(201, "CREATE", "회원 가입에 성공하였습니다."),
-    SIGN_IN(201, "CREATE", "로그인에 성공하였습니다.");;
+    SIGN_IN(200, "OK", "로그인에 성공하였습니다.");;
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/signaling/signaling_server/common/type/success/AuthSuccessType.java
+++ b/src/main/java/org/signaling/signaling_server/common/type/success/AuthSuccessType.java
@@ -1,7 +1,8 @@
 package org.signaling.signaling_server.common.type.success;
 
 public enum AuthSuccessType implements SuccessTypeCode {
-    SIGN_UP(201, "CREATE", "회원 가입에 성공하였습니다.");
+    SIGN_UP(201, "CREATE", "회원 가입에 성공하였습니다."),
+    SIGN_IN(201, "CREATE", "로그인에 성공하였습니다.");;
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/signaling/signaling_server/common/utils/JwtUtils.java
+++ b/src/main/java/org/signaling/signaling_server/common/utils/JwtUtils.java
@@ -31,13 +31,13 @@ public class JwtUtils {
         this.key = Keys.hmacShaKeyFor(decodedKey);
     }
 
-    public String generateAccessToken(String nickname, Long memberId) {
+    public String generateAccessToken(String name, Long memberId) {
         Date nowDate = new Date();
         Date expiration = new Date(nowDate.getTime() + Duration.ofHours(2).toMillis());
         String jwtToken =
                 Jwts.builder()
-                        .claim("name", nickname)
-                        .claim("sub", "signaling")
+                        .claim("name", name)
+                        .claim("sub", "accessToken")
                         .claim("jti", String.valueOf(memberId))
                         .claim("iat", nowDate)
                         .claim("exp", expiration)
@@ -47,13 +47,13 @@ public class JwtUtils {
         return jwtToken;
     }
 
-    public String generateRefreshToken(String nickname, Long memberId) {
+    public String generateRefreshToken(String name, Long memberId) {
         Date nowDate = new Date();
         Date expiration = new Date(nowDate.getTime() + Duration.ofDays(30).toMillis());
         String jwtToken =
                 Jwts.builder()
-                        .claim("name", nickname)
-                        .claim("sub", "meong-ha-nyang")
+                        .claim("name", name)
+                        .claim("sub", "refreshToken")
                         .claim("jti", String.valueOf(memberId))
                         .claim("iat", nowDate)
                         .claim("exp", expiration)

--- a/src/main/java/org/signaling/signaling_server/config/ObjectMapperConfig.java
+++ b/src/main/java/org/signaling/signaling_server/config/ObjectMapperConfig.java
@@ -1,0 +1,34 @@
+package org.signaling.signaling_server.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper(){
+        var objectMapper = new ObjectMapper();
+
+        // Jdk8Module과 JavaTimeModule 등록으로 Optional, LocalDate와 같은 Java 8 클래스 직렬화 지원
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.registerModule(new JavaTimeModule());
+
+        // 알 수 없는 필드 무시
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+        // 스네이크 케이스
+        objectMapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
+
+        return objectMapper;
+    }
+
+
+}

--- a/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthOpenApiController.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthOpenApiController.java
@@ -4,7 +4,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.signaling.signaling_server.common.api.Api;
 import org.signaling.signaling_server.common.type.success.AuthSuccessType;
+import org.signaling.signaling_server.domain.auth.dto.request.SignInRequest;
 import org.signaling.signaling_server.domain.auth.dto.request.SignUpRequest;
+import org.signaling.signaling_server.domain.auth.dto.response.SignInResponse;
 import org.signaling.signaling_server.domain.auth.service.AuthService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,5 +25,14 @@ public class AuthOpenApiController {
     ){
         authService.signUp(signUpRequest);
         return Api.success(AuthSuccessType.SIGN_UP);
+    }
+
+    @PostMapping("/sign-in")
+    public Api<SignInResponse> signIn(
+            @Valid
+            @RequestBody SignInRequest signInRequest
+    ){
+            SignInResponse signInResponse = authService.signIn(signInRequest);
+            return Api.success(AuthSuccessType.SIGN_IN,signInResponse);
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/auth/dto/request/SignInRequest.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/dto/request/SignInRequest.java
@@ -1,0 +1,12 @@
+package org.signaling.signaling_server.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "로그인을 위한 요청")
+public record SignInRequest(
+        @NotBlank @Schema(description = "아이디", example = "test1234") String username,
+        @NotBlank @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.") @Schema(description = "비밀번호", example = "test1234!") String password
+) {
+}

--- a/src/main/java/org/signaling/signaling_server/domain/auth/dto/response/SignInResponse.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/dto/response/SignInResponse.java
@@ -1,0 +1,13 @@
+package org.signaling.signaling_server.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record SignInResponse(
+        @NotBlank @Schema(description = "access token", example = "Bearer asdf...") String accessToken,
+        @NotBlank @Schema(description = "refresh token", example = "Bearer asdf...") String refreshToken
+) {
+}

--- a/src/main/java/org/signaling/signaling_server/domain/auth/mapper/AuthResponseMapper.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/mapper/AuthResponseMapper.java
@@ -1,0 +1,12 @@
+package org.signaling.signaling_server.domain.auth.mapper;
+
+import org.signaling.signaling_server.domain.auth.dto.response.SignInResponse;
+
+public class AuthResponseMapper {
+    public static SignInResponse from(String accessToken, String refreshToken){
+        return SignInResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/signaling/signaling_server/domain/auth/mapper/RefreshTokenEntityMapper.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/mapper/RefreshTokenEntityMapper.java
@@ -1,0 +1,16 @@
+package org.signaling.signaling_server.domain.auth.mapper;
+
+import org.signaling.signaling_server.domain.auth.dto.request.SignUpRequest;
+import org.signaling.signaling_server.entity.member.MemberEntity;
+import org.signaling.signaling_server.redis.RefreshToken;
+
+import java.time.LocalDateTime;
+
+public class RefreshTokenEntityMapper {
+    public static RefreshToken of(Long memberId, String refreshToken){
+        return RefreshToken.builder()
+                .refreshToken(refreshToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/signaling/signaling_server/domain/auth/service/AuthService.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/service/AuthService.java
@@ -4,17 +4,29 @@ import lombok.RequiredArgsConstructor;
 import org.signaling.signaling_server.common.exception.ApiException;
 import org.signaling.signaling_server.common.exception.ApiExceptionImpl;
 import org.signaling.signaling_server.common.exception.BadRequestException;
+import org.signaling.signaling_server.common.exception.NotFoundException;
 import org.signaling.signaling_server.common.type.error.AuthErrorType;
+import org.signaling.signaling_server.common.utils.JwtUtils;
+import org.signaling.signaling_server.domain.auth.dto.request.SignInRequest;
 import org.signaling.signaling_server.domain.auth.dto.request.SignUpRequest;
+import org.signaling.signaling_server.domain.auth.dto.response.SignInResponse;
 import org.signaling.signaling_server.domain.auth.mapper.AuthEntityMapper;
+import org.signaling.signaling_server.domain.auth.mapper.AuthResponseMapper;
+import org.signaling.signaling_server.domain.auth.mapper.RefreshTokenEntityMapper;
 import org.signaling.signaling_server.domain.member.repository.MemberRepository;
 import org.signaling.signaling_server.entity.member.MemberEntity;
+import org.signaling.signaling_server.redis.RefreshToken;
+import org.signaling.signaling_server.redis.RefreshTokenRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
     private final MemberRepository memberRepository;
+    private final JwtUtils jwtUtils;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public void signUp(SignUpRequest signUpRequest){
 
@@ -38,5 +50,28 @@ public class AuthService {
 
         //회원저장
         memberRepository.save(memberEntity);
+    }
+
+    public SignInResponse signIn(SignInRequest signInRequest) {
+        MemberEntity memberEntity = memberRepository.findByUsername(signInRequest.username())
+                .orElseThrow(()-> new NotFoundException(AuthErrorType.NOT_FOUND));
+
+        //비밀번호 비교
+        if(bCryptPasswordEncoder.matches(signInRequest.password(),memberEntity.getPassword())){
+            throw new BadRequestException(AuthErrorType.PASSWORD_NOT_MATCH);
+        }
+
+        //access token, refresh token 생성
+        String accessToken = jwtUtils.generateAccessToken(memberEntity.getName(), memberEntity.getId());
+        String refreshToken = jwtUtils.generateRefreshToken(memberEntity.getName(), memberEntity.getId());
+
+        //refresh token redis 저장
+        RefreshToken refreshTokenEntity = RefreshTokenEntityMapper.of(memberEntity.getId(), refreshToken);
+        refreshTokenRepository.save(refreshTokenEntity);
+
+        accessToken = jwtUtils.includeBearer(accessToken);
+        refreshToken = jwtUtils.includeBearer(refreshToken);
+
+        return AuthResponseMapper.from(accessToken,refreshToken);
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/member/repository/JpaMemberRepository.java
+++ b/src/main/java/org/signaling/signaling_server/domain/member/repository/JpaMemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface JpaMemberRepository extends JpaRepository<MemberEntity, Long> {
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
+
+    Optional<MemberEntity> findByUsername(String username);
 }

--- a/src/main/java/org/signaling/signaling_server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/signaling/signaling_server/domain/member/repository/MemberRepository.java
@@ -13,4 +13,5 @@ public interface MemberRepository {
 
     void save(MemberEntity memberEntity);
 
+    Optional<MemberEntity> findByUsername(String username);
 }

--- a/src/main/java/org/signaling/signaling_server/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/org/signaling/signaling_server/domain/member/repository/MemberRepositoryImpl.java
@@ -31,5 +31,10 @@ public class MemberRepositoryImpl implements MemberRepository {
         jpaMemberRepository.save(memberEntity);
     }
 
+    @Override
+    public Optional<MemberEntity> findByUsername(String username) {
+        return jpaMemberRepository.findByUsername(username);
+    }
+
 
 }

--- a/src/main/java/org/signaling/signaling_server/redis/RefreshToken.java
+++ b/src/main/java/org/signaling/signaling_server/redis/RefreshToken.java
@@ -1,0 +1,22 @@
+package org.signaling.signaling_server.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@AllArgsConstructor
+@Builder
+@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 14)
+public class RefreshToken {
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    private Long memberId;
+}

--- a/src/main/java/org/signaling/signaling_server/redis/RefreshTokenRepository.java
+++ b/src/main/java/org/signaling/signaling_server/redis/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package org.signaling.signaling_server.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    void deleteByMemberId(Long memberId);
+}


### PR DESCRIPTION
- JWT를 활용하여 access token과 refresh token을 생성하였습니다.
- refresh token은 redis에 유효기간 동안 저장하였습니다.
- JWT subject를 통해 access token과 refresh token을 구분하였습니다.
- spring boot의 camel case를 API를 통해 Response dto로 내보낼때 snake case로 변환하여 보내도록 ObjectMapperConfig를 통해 변경하도록 하였습니다.

![스크린샷 2025-01-14 오후 6 54 47](https://github.com/user-attachments/assets/24844066-ce00-478d-8a08-60ea9f74ca7f)
