### PR TITLE
feat: access token 재발급 구현

### DIFF
--- a/src/main/java/org/signaling/signaling_server/common/type/success/AuthSuccessType.java
+++ b/src/main/java/org/signaling/signaling_server/common/type/success/AuthSuccessType.java
@@ -3,7 +3,8 @@ package org.signaling.signaling_server.common.type.success;
 public enum AuthSuccessType implements SuccessTypeCode {
     SIGN_UP(201, "CREATE", "회원 가입에 성공하였습니다."),
     SIGN_IN(200, "OK", "로그인에 성공하였습니다."),
-    SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다.");
+    SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다."),
+    REISSUE_ACCESS_TOKEN(200, "OK", "ACCESS TOKEN 재발행에 성공하였습니다.");
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthApi.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthApi.java
@@ -3,6 +3,7 @@ package org.signaling.signaling_server.domain.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.signaling.signaling_server.common.api.Api;
+import org.signaling.signaling_server.domain.auth.dto.response.ReissueAccessTokenResponse;
 import org.signaling.signaling_server.domain.auth.dto.response.SignInResponse;
 import org.springframework.security.core.Authentication;
 
@@ -10,4 +11,7 @@ import org.springframework.security.core.Authentication;
 public interface AuthApi {
     @Operation(summary = "로그아웃을 합니다.", description = "담당자: 최민석")
     Api<SignInResponse> signOut(Authentication authentication, String accessToken);
+
+    @Operation(summary = "Access Token을 재발급합니다.", description = "담당자: 최민석")
+    Api<ReissueAccessTokenResponse> reissueAccessToken(Authentication authentication, String refreshToken);
 }

--- a/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthApiController.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthApiController.java
@@ -3,6 +3,7 @@ package org.signaling.signaling_server.domain.auth.controller;
 import lombok.RequiredArgsConstructor;
 import org.signaling.signaling_server.common.api.Api;
 import org.signaling.signaling_server.common.type.success.AuthSuccessType;
+import org.signaling.signaling_server.domain.auth.dto.response.ReissueAccessTokenResponse;
 import org.signaling.signaling_server.domain.auth.dto.response.SignInResponse;
 import org.signaling.signaling_server.domain.auth.service.AuthService;
 import org.springframework.security.core.Authentication;
@@ -16,9 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthApiController implements AuthApi{
     private final AuthService authService;
+
+    //로그아웃
     @PostMapping("/sign-out")
     public Api<SignInResponse> signOut(Authentication authentication, @RequestHeader("Authorization") String accessToken) {
         authService.signOut(authentication,accessToken);
         return Api.success(AuthSuccessType.SIGN_OUT);
+    }
+
+    // Acess Token 토큰 재발급
+    @PostMapping("/reissue-token")
+    public Api<ReissueAccessTokenResponse> reissueAccessToken(Authentication authentication, @RequestHeader("Authorization") String refreshToken) {
+        ReissueAccessTokenResponse reissueAccessToken = authService.ReissueAccessToken(authentication, refreshToken);
+        return Api.success(AuthSuccessType.REISSUE_ACCESS_TOKEN,reissueAccessToken);
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/auth/dto/response/ReissueAccessTokenResponse.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/dto/response/ReissueAccessTokenResponse.java
@@ -1,0 +1,11 @@
+package org.signaling.signaling_server.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record ReissueAccessTokenResponse(
+        @NotBlank @Schema(description = "access token", example = "Bearer asdf...") String accessToken
+) {
+}

--- a/src/main/java/org/signaling/signaling_server/domain/auth/mapper/AuthResponseMapper.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/mapper/AuthResponseMapper.java
@@ -1,12 +1,19 @@
 package org.signaling.signaling_server.domain.auth.mapper;
 
+import org.signaling.signaling_server.domain.auth.dto.response.ReissueAccessTokenResponse;
 import org.signaling.signaling_server.domain.auth.dto.response.SignInResponse;
 
 public class AuthResponseMapper {
-    public static SignInResponse from(String accessToken, String refreshToken){
+    public static SignInResponse toSignInResponse(String accessToken, String refreshToken){
         return SignInResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .build();
+    }
+
+    public static ReissueAccessTokenResponse toReissueAccessTokenResponse(String accessToken){
+        return ReissueAccessTokenResponse.builder()
+                .accessToken(accessToken)
                 .build();
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/auth/mapper/TokenEntityMapper.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/mapper/TokenEntityMapper.java
@@ -4,10 +4,10 @@ import org.signaling.signaling_server.redis.AccessToken;
 import org.signaling.signaling_server.redis.RefreshToken;
 
 public class TokenEntityMapper {
-    public static RefreshToken toRefreshToken(Long memberId, String refreshToken){
+    public static RefreshToken toRefreshToken(String accessToken, String refreshToken){
         return RefreshToken.builder()
                 .refreshToken(refreshToken)
-                .refreshToken(refreshToken)
+                .accessToken(accessToken)
                 .build();
     }
     public static AccessToken toAccessToken(Long ttl, String accessToken){

--- a/src/main/java/org/signaling/signaling_server/redis/RefreshToken.java
+++ b/src/main/java/org/signaling/signaling_server/redis/RefreshToken.java
@@ -18,5 +18,6 @@ public class RefreshToken {
     @Indexed
     private String refreshToken;
 
-    private Long memberId;
+    @Indexed
+    private String accessToken;
 }

--- a/src/main/java/org/signaling/signaling_server/redis/RefreshTokenRepository.java
+++ b/src/main/java/org/signaling/signaling_server/redis/RefreshTokenRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 
-    void deleteByMemberId(Long memberId);
+    void deleteByAccessToken(String AccessToken);
 }


### PR DESCRIPTION
1. redis에서 refresh token 유무 확인
2. 기존 access token 유효기간 확인 후 블랙리스트 처리
3. 새로운 access token 발급
4. refresh token 확인용 access token 전환
5. response 전송

- 토큰 재발급
![스크린샷 2025-01-14 오후 9 41 36](https://github.com/user-attachments/assets/5b94fdc8-92e2-49b8-a33a-92f7d9f3141a)

-토큰 재발급 후 발급 받기 전 access token을 사용하여 로그아웃
![스크린샷 2025-01-14 오후 9 42 57](https://github.com/user-attachments/assets/0503ccdf-2d0d-4bd6-9c63-49cea958111e)

- 재발급 받은 access token을 사용하여 로그아웃
![스크린샷 2025-01-14 오후 9 42 46](https://github.com/user-attachments/assets/2787d7b8-62c3-413a-822e-a16806d43893)

- 로그아웃 후 refresh token을 사용하여 토큰 재발급
![스크린샷 2025-01-14 오후 9 43 38](https://github.com/user-attachments/assets/d46dfa39-e3bd-4e0e-8009-c8fa30e332c5)
