### PR TITLE
feat: 이메일 인증 코드 발송 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.4.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/signaling/signaling_server/common/type/error/AuthErrorType.java
+++ b/src/main/java/org/signaling/signaling_server/common/type/error/AuthErrorType.java
@@ -6,7 +6,8 @@ public enum AuthErrorType implements ErrorTypeCode {
     HEADER_INVALID("UNAUTHORIZED", "AUTHORIZATION 헤더가 누락되었거나 토큰 형식에 오류가 있습니다."),
     EMAIL_DUPLICATED("BAD REQUEST", "이메일이 중복되었습니다."),
     USERNAME_DUPLICATED("BAD REQUEST", "아이디가 중복되었습니다."),
-    PASSWORD_NOT_MATCH("BAD REQUEST", "비밀번호가 일치하지 않습니다.");
+    PASSWORD_NOT_MATCH("BAD REQUEST", "비밀번호가 일치하지 않습니다."),
+    EMAIL_SEND_FAIL("INTERNAL SERVER ERROR", "이메일 전송에 실패하였습니다.");
 
     private final String message;
     private final String description;

--- a/src/main/java/org/signaling/signaling_server/common/type/success/AuthSuccessType.java
+++ b/src/main/java/org/signaling/signaling_server/common/type/success/AuthSuccessType.java
@@ -4,7 +4,8 @@ public enum AuthSuccessType implements SuccessTypeCode {
     SIGN_UP(201, "CREATE", "회원 가입에 성공하였습니다."),
     SIGN_IN(200, "OK", "로그인에 성공하였습니다."),
     SIGN_OUT(200, "OK", "로그아웃에 성공하였습니다."),
-    REISSUE_ACCESS_TOKEN(200, "OK", "ACCESS TOKEN 재발행에 성공하였습니다.");
+    REISSUE_ACCESS_TOKEN(200, "OK", "ACCESS TOKEN 재발행에 성공하였습니다."),
+    EMAIL_SEND_SUCCESS(200,"OK", "이메일로 인증 코드 전송에 성공하였습니다.");
 
     private final Integer code;
     private final String message;

--- a/src/main/java/org/signaling/signaling_server/config/MailConfig.java
+++ b/src/main/java/org/signaling/signaling_server/config/MailConfig.java
@@ -1,0 +1,35 @@
+package org.signaling.signaling_server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthOpenApi.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthOpenApi.java
@@ -3,6 +3,7 @@ package org.signaling.signaling_server.domain.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.signaling.signaling_server.common.api.Api;
+import org.signaling.signaling_server.domain.auth.dto.request.EmailRequest;
 import org.signaling.signaling_server.domain.auth.dto.request.SignInRequest;
 import org.signaling.signaling_server.domain.auth.dto.request.SignUpRequest;
 import org.signaling.signaling_server.domain.auth.dto.response.SignInResponse;
@@ -15,4 +16,6 @@ public interface AuthOpenApi {
 
     @Operation(summary = "로그인을 합니다.", description = "담당자: 최민석")
     Api<SignInResponse> signIn(SignInRequest signInRequest);
+    @Operation(summary = "이메일 인증코드를 발송합니다.", description = "담당자: 최민석")
+    Api<?> sendCode(EmailRequest emailRequest);
 }

--- a/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthOpenApiController.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/controller/AuthOpenApiController.java
@@ -4,11 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.signaling.signaling_server.common.api.Api;
 import org.signaling.signaling_server.common.type.success.AuthSuccessType;
+import org.signaling.signaling_server.domain.auth.dto.request.EmailRequest;
 import org.signaling.signaling_server.domain.auth.dto.request.SignInRequest;
 import org.signaling.signaling_server.domain.auth.dto.request.SignUpRequest;
 import org.signaling.signaling_server.domain.auth.dto.response.SignInResponse;
 import org.signaling.signaling_server.domain.auth.service.AuthService;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +35,14 @@ public class AuthOpenApiController implements AuthOpenApi {
     ){
             SignInResponse signInResponse = authService.signIn(signInRequest);
             return Api.success(AuthSuccessType.SIGN_IN,signInResponse);
+    }
+
+    @PostMapping("/email-verification")
+    public Api<?> sendCode(
+            @Valid
+            @RequestBody EmailRequest emailRequest
+    ){
+        authService.sendCode(emailRequest);
+        return Api.success(AuthSuccessType.EMAIL_SEND_SUCCESS);
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/auth/dto/request/EmailRequest.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/dto/request/EmailRequest.java
@@ -1,0 +1,10 @@
+package org.signaling.signaling_server.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "이메일 인증을 위한 인증코드 요청")
+public record EmailRequest(
+        @NotBlank @Schema(description = "이메일", example = "test1234@gmail.com") String email
+) {
+}

--- a/src/main/java/org/signaling/signaling_server/domain/auth/mapper/AuthEntityMapper.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/mapper/AuthEntityMapper.java
@@ -2,6 +2,7 @@ package org.signaling.signaling_server.domain.auth.mapper;
 
 import org.signaling.signaling_server.domain.auth.dto.request.SignUpRequest;
 import org.signaling.signaling_server.entity.member.MemberEntity;
+import org.signaling.signaling_server.redis.EmailCode;
 
 import java.time.LocalDateTime;
 
@@ -18,6 +19,13 @@ public class AuthEntityMapper {
                 .username(signUpRequest.username())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static EmailCode toEmailCode(String email, String code){
+        return EmailCode.builder()
+                .email(email)
+                .code(code)
                 .build();
     }
 }

--- a/src/main/java/org/signaling/signaling_server/redis/EmailCode.java
+++ b/src/main/java/org/signaling/signaling_server/redis/EmailCode.java
@@ -1,0 +1,22 @@
+package org.signaling.signaling_server.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RedisHash(value = "emailCode", timeToLive = 60)
+public class EmailCode {
+    @Id
+    private Long id;
+
+    @Indexed
+    private String email;
+
+    private String code;
+}

--- a/src/main/java/org/signaling/signaling_server/redis/EmailCodeRepository.java
+++ b/src/main/java/org/signaling/signaling_server/redis/EmailCodeRepository.java
@@ -1,0 +1,9 @@
+package org.signaling.signaling_server.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface EmailCodeRepository extends CrudRepository<EmailCode, String> {
+    Optional<EmailCode> findByEmail(String email);
+}

--- a/src/main/resources/application-mail.yaml
+++ b/src/main/resources/application-mail.yaml
@@ -1,0 +1,17 @@
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GOOGLE_EMAIL}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 1800000

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,5 +4,5 @@ spring:
   profiles:
     active: dev
     group:
-      dev: db, key
-      prod: db, key
+      dev: db, key, mail
+      prod: db, key, mail


### PR DESCRIPTION
- gmail smtp를 활용하여 메일을 보냈습니다.
1. 이미 존재하는 이메일인지 확인합니다.
2. 랜덤 문자열을 생성하여 이메일과 같이 redis에 1분간 저장합니다.
3. 메일을 전송합니다.

- 이메일이 존재할 경우
![스크린샷 2025-01-15 오후 6 12 54](https://github.com/user-attachments/assets/3d3653f0-ff18-40f1-87cb-b7cfb0562bdb)


- 성공
![스크린샷 2025-01-15 오후 6 11 41](https://github.com/user-attachments/assets/66ce6d63-0b49-45f7-b408-f2ea65efa133)
![스크린샷 2025-01-15 오후 6 11 55](https://github.com/user-attachments/assets/b81af5fd-fa40-4442-87a6-cabefe57de21)

