### PR TITLE
feat: 친구 목록 조회 및 검색

### DIFF
--- a/src/main/java/org/signaling/signaling_server/common/type/success/FriendSuccessType.java
+++ b/src/main/java/org/signaling/signaling_server/common/type/success/FriendSuccessType.java
@@ -3,7 +3,8 @@ package org.signaling.signaling_server.common.type.success;
 public enum FriendSuccessType implements SuccessTypeCode {
     ADD_FRIEND(200, "OK", "친구추가 요청을 성공하였습니다"),
     ACCEPT_ADD_FRIEND(200, "OK", "친구추가 허가 요청을 성공하였습니다"),
-    DELETE_FRIEND(200, "OK", "친구 삭제 요청을 성공하였습니다")
+    DELETE_FRIEND(200, "OK", "친구 삭제 요청을 성공하였습니다"),
+    SEARCH_FRIEND(200, "OK", "친구 검색 및 목록 조회 요청을 성공하였습니다.")
     ;
     private final Integer code;
     private final String message;

--- a/src/main/java/org/signaling/signaling_server/domain/friend/controller/FriendApi.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/controller/FriendApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.signaling.signaling_server.common.api.Api;
 import org.signaling.signaling_server.domain.friend.dto.request.FriendIdRequest;
 import org.signaling.signaling_server.domain.friend.dto.request.AddFriendRequest;
+import org.signaling.signaling_server.domain.friend.dto.response.FriendInfoListResponse;
 import org.springframework.security.core.Authentication;
 
 @Tag(name = "Friend Api", description = "친구 관련 API 목록입니다.")
@@ -17,5 +18,8 @@ public interface FriendApi {
 
     @Operation(summary = "친구삭제를 합니다.", description = "담당자: 최민석")
     Api<?> deleteFriend(FriendIdRequest friendIdRequest, Authentication authentication);
+
+    @Operation(summary = "친구를 검색합니다.", description = "담당자: 최민석")
+    Api<FriendInfoListResponse> searchToFriend(String nickname, Authentication authentication);
 
 }

--- a/src/main/java/org/signaling/signaling_server/domain/friend/controller/FriendApiController.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/controller/FriendApiController.java
@@ -6,6 +6,7 @@ import org.signaling.signaling_server.common.api.Api;
 import org.signaling.signaling_server.common.type.success.FriendSuccessType;
 import org.signaling.signaling_server.domain.friend.dto.request.FriendIdRequest;
 import org.signaling.signaling_server.domain.friend.dto.request.AddFriendRequest;
+import org.signaling.signaling_server.domain.friend.dto.response.FriendInfoListResponse;
 import org.signaling.signaling_server.domain.friend.service.FriendService;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -46,5 +47,14 @@ public class FriendApiController implements FriendApi {
     ) {
         friendService.deleteFriend(friendIdRequest, authentication);
         return Api.success(FriendSuccessType.DELETE_FRIEND);
+    }
+
+    @GetMapping
+    public Api<FriendInfoListResponse> searchToFriend(
+            @RequestParam String nickname,
+            Authentication authentication
+    ) {
+        FriendInfoListResponse friendInfoListResponse = friendService.searchToFriend(nickname,authentication);
+        return Api.success(FriendSuccessType.SEARCH_FRIEND,friendInfoListResponse);
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/friend/dto/FriendInfoDto.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/dto/FriendInfoDto.java
@@ -1,0 +1,13 @@
+package org.signaling.signaling_server.domain.friend.dto;
+
+
+import org.signaling.signaling_server.entity.friend.enums.FriendStatus;
+
+public record FriendInfoDto(
+        Long friendId,
+        Long memberId,
+        String nickname,
+        FriendStatus friendStatus
+) {
+
+}

--- a/src/main/java/org/signaling/signaling_server/domain/friend/dto/response/FriendInfoListResponse.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/dto/response/FriendInfoListResponse.java
@@ -1,0 +1,14 @@
+package org.signaling.signaling_server.domain.friend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "친구 정보 목록 조회 응답")
+public record FriendInfoListResponse(
+        @NotNull @Schema(description = "친구 정보 목록")List<FriendInfoResponse> friendList
+) {
+}

--- a/src/main/java/org/signaling/signaling_server/domain/friend/dto/response/FriendInfoResponse.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/dto/response/FriendInfoResponse.java
@@ -1,0 +1,17 @@
+package org.signaling.signaling_server.domain.friend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import org.signaling.signaling_server.entity.friend.enums.FriendStatus;
+
+@Builder
+@Schema(description = "친구 정보 조회를 위한 응답")
+public record FriendInfoResponse(
+        @NotNull @Schema(description = "친구 테이블 고유 아이디", example = "1") Long friendId,
+        @NotNull @Schema(description = "친구 유저 고유 아이디", example = "2") Long memberId,
+        @NotBlank @Schema(description = "회원 닉네임", example = "무심천자전거길") String nickname,
+        @NotBlank @Schema(description = "친구 요청 상태", example = "ACCEPT") FriendStatus friendStatus
+) {
+}

--- a/src/main/java/org/signaling/signaling_server/domain/friend/mapper/FriendResponseMapper.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/mapper/FriendResponseMapper.java
@@ -1,10 +1,16 @@
 package org.signaling.signaling_server.domain.friend.mapper;
 
 
+import org.signaling.signaling_server.domain.friend.dto.FriendInfoDto;
 import org.signaling.signaling_server.domain.friend.dto.request.AddFriendRequest;
+import org.signaling.signaling_server.domain.friend.dto.response.FriendInfoListResponse;
+import org.signaling.signaling_server.domain.friend.dto.response.FriendInfoResponse;
+import org.signaling.signaling_server.entity.friend.FriendEntity;
 import org.signaling.signaling_server.entity.friend.enums.FriendStatus;
 import org.signaling.signaling_server.entity.member.MemberEntity;
 import org.signaling.signaling_server.kafka.dto.FriendNotification;
+
+import java.util.List;
 
 public class FriendResponseMapper {
 
@@ -16,6 +22,21 @@ public class FriendResponseMapper {
                 .toMemberId(friendRequest.toMemberId())
                 .status(status)
                 .message(message)
+                .build();
+    }
+
+    public static FriendInfoResponse toFriendInfoResponse(FriendInfoDto friendInfoDto){
+        return FriendInfoResponse.builder()
+                .friendId(friendInfoDto.friendId())
+                .memberId(friendInfoDto.memberId())
+                .nickname(friendInfoDto.nickname())
+                .friendStatus(friendInfoDto.friendStatus())
+                .build();
+    }
+
+    public static FriendInfoListResponse toFriendInfoListResponse(List<FriendInfoResponse> friendInfoResponseList){
+        return FriendInfoListResponse.builder()
+                .friendList(friendInfoResponseList)
                 .build();
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/repository/FriendRepository.java
@@ -1,7 +1,11 @@
 package org.signaling.signaling_server.domain.friend.repository;
 
+import org.signaling.signaling_server.domain.friend.dto.FriendInfoDto;
 import org.signaling.signaling_server.entity.friend.FriendEntity;
 import org.signaling.signaling_server.entity.friend.enums.FriendStatus;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface FriendRepository {
     void save(FriendEntity friendEntity);
@@ -11,4 +15,6 @@ public interface FriendRepository {
     boolean existsByIdAndToMemberId(Long id, Long toMemberId);
 
     void deleteByIdAndFromMemberOrToMember(Long friendId, Long memberId);
+
+    List<FriendInfoDto> findByMemberId(String nickname, Long memberId);
 }

--- a/src/main/java/org/signaling/signaling_server/domain/friend/repository/FriendRepositoryImpl.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/repository/FriendRepositoryImpl.java
@@ -1,12 +1,18 @@
 package org.signaling.signaling_server.domain.friend.repository;
 
 import static org.signaling.signaling_server.entity.friend.QFriendEntity.friendEntity;
+import static org.signaling.signaling_server.entity.member.QMemberEntity.memberEntity;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.signaling.signaling_server.domain.friend.dto.FriendInfoDto;
 import org.signaling.signaling_server.entity.friend.FriendEntity;
 import org.signaling.signaling_server.entity.friend.enums.FriendStatus;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -48,5 +54,41 @@ public class FriendRepositoryImpl implements FriendRepository {
                                 )
                 )
                 .execute();
+    }
+
+    @Override
+    public List<FriendInfoDto> findByMemberId(String nickname, Long memberId) {
+        return jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                FriendInfoDto.class,
+                                friendEntity.id, // friendId
+                                friendEntity.fromMemberId
+                                        .when(memberId).then(friendEntity.toMemberId) // b가 from이면 to를 가져옴
+                                        .otherwise(friendEntity.fromMemberId),       // b가 to이면 from을 가져옴
+                                memberEntity.nickname,                          // 해당 memberId의 nickname 가져오기
+                                friendEntity.status                             // friendStatus 추가
+                        )
+                )
+                .from(friendEntity)
+                .leftJoin(memberEntity) // member 테이블과 조인
+                .on(
+                        friendEntity.fromMemberId.when(memberId).then(friendEntity.toMemberId)
+                                .otherwise(friendEntity.fromMemberId).eq(memberEntity.id)
+                )
+                .where(
+                        friendEntity.fromMemberId.eq(memberId)
+                                .or(friendEntity.toMemberId.eq(memberId))
+                                .and(
+                                        nickname == null || nickname.isEmpty() // nickname 조건 추가
+                                                ? null // 빈 문자열이면 조건 무시
+                                                : memberEntity.nickname.contains(nickname) // 특정 문자열 포함
+                                )
+                )
+                .orderBy(
+                        friendEntity.status.asc(), // REQUEST를 위로 올림 (REQUEST < ACCEPTED)
+                        friendEntity.id.asc()       // 같은 상태에서는 friendId 기준 정렬
+                )
+                .fetch();
     }
 }


### PR DESCRIPTION
- sql문을 사용하여 검색 기능 구현
- 친구 대상인 fromMemberId와 toMemberId인지를 확인 후 memberId로 전환하여 응답
- contain을 사용하여 nickname으로 검색 nickname이 빈문자열이라면 전체 검색으로 구현하였습니다.

- 전체 검색
![스크린샷 2025-01-18 오후 12 15 59](https://github.com/user-attachments/assets/0f5c2333-4321-4a42-b759-4b54d1a108cd)

- "자"로 검색
![스크린샷 2025-01-18 오후 12 16 09](https://github.com/user-attachments/assets/5ecba6ac-a722-4852-86f5-70e1d2878f56)

- "자전거"로 검색
![스크린샷 2025-01-18 오후 12 16 17](https://github.com/user-attachments/assets/29891523-1c61-4f8a-9138-05a33aa248f9)
