### PR TITLE
feat: webRTC signering server 구현

### DIFF
--- a/src/main/java/org/signaling/signaling_server/common/api/Api.java
+++ b/src/main/java/org/signaling/signaling_server/common/api/Api.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import org.signaling.signaling_server.common.exception.ApiException;
 import org.signaling.signaling_server.common.type.error.ErrorTypeCode;
 import org.signaling.signaling_server.common.type.success.SuccessTypeCode;
+import org.springframework.http.HttpStatus;
 
 @JsonPropertyOrder({"result", "body"})
 // 공통 응답 class
@@ -25,6 +26,10 @@ public record Api<T>(Result result, @JsonInclude(JsonInclude.Include.NON_NULL) @
 
     public static <T> Api<T> fail(ErrorTypeCode errorType) {
         return new Api<>(new Result(errorType), null);
+    }
+
+    public static <T> Api<T> fail(ErrorTypeCode errorType, HttpStatus httpStatus) {
+        return new Api<>(new Result(httpStatus, errorType), null);
     }
 
     public static <T> Api<T> fail(ErrorTypeCode errorType, T body) {

--- a/src/main/java/org/signaling/signaling_server/common/api/Result.java
+++ b/src/main/java/org/signaling/signaling_server/common/api/Result.java
@@ -29,6 +29,7 @@ public class Result {
         this.description = errorTypeCode.getDescription();
     }
 
+
     public Result(HttpStatus httpStatus, ErrorTypeCode errorTypeCode) {
         this.code = httpStatus.value();
         this.message = errorTypeCode.getMessage();

--- a/src/main/java/org/signaling/signaling_server/config/SecurityConfig.java
+++ b/src/main/java/org/signaling/signaling_server/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("http://localhost:3000")); // React 클라이언트 허용
+        configuration.setAllowedOriginPatterns(List.of("*")); // React 클라이언트 허용
         configuration.setAllowCredentials(true); // 인증 포함 요청 허용
         configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
         configuration.addAllowedHeader("*"); // 모든 헤더 허용

--- a/src/main/java/org/signaling/signaling_server/config/WebSocketConfig.java
+++ b/src/main/java/org/signaling/signaling_server/config/WebSocketConfig.java
@@ -14,7 +14,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("http://localhost:3000") // React 클라이언트 허용
+                .setAllowedOriginPatterns("*") // React 클라이언트 허용
                 .withSockJS();
     }
 

--- a/src/main/java/org/signaling/signaling_server/domain/auth/service/AuthService.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/service/AuthService.java
@@ -173,6 +173,8 @@ public class AuthService {
 
         String code = getCode();
 
+        emailCodeRepository.deleteByEmail(emailRequest.email());
+
         EmailCode emailCode = AuthEntityMapper.toEmailCode(emailRequest.email(),code);
 
         //코드 redis 저장

--- a/src/main/java/org/signaling/signaling_server/domain/auth/service/AuthService.java
+++ b/src/main/java/org/signaling/signaling_server/domain/auth/service/AuthService.java
@@ -128,17 +128,6 @@ public class AuthService {
         RefreshToken refreshTokenEntity = refreshTokenRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(()->new UnauthorizedException(AuthErrorType.TOKEN_NOT_FOUND));
 
-        String accessToken = refreshTokenEntity.getAccessToken();
-
-        //access token 남은 시간 계산
-        Date date = jwtUtils.getExpirationDateFromToken(accessToken);
-        long ttl = (date.getTime() - System.currentTimeMillis()) / 1000;
-
-        AccessToken accessTokenEntity = TokenEntityMapper.toAccessToken(ttl,accessToken);
-
-        //기존 access token 블랙리스트
-        accessTokenRepository.save(accessTokenEntity);
-
         //access token 재발급
         String newAccessToken = jwtUtils.generateAccessToken(userDetails.getMemberEntity().getUsername(), userDetails.getId());
 

--- a/src/main/java/org/signaling/signaling_server/domain/callroom/controller/CallRoomApiController.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroom/controller/CallRoomApiController.java
@@ -5,6 +5,9 @@ import org.signaling.signaling_server.common.api.Api;
 import org.signaling.signaling_server.common.type.success.CallRoomSuccessType;
 import org.signaling.signaling_server.domain.callroom.dto.response.CallRoomInfoListResponse;
 import org.signaling.signaling_server.domain.callroom.service.CallRoomService;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,5 +31,23 @@ public class CallRoomApiController implements CallRoomApi {
     ) {
         CallRoomInfoListResponse callRoomInfoListResponse = callRoomService.searchRoom(search, authentication);
         return Api.success(CallRoomSuccessType.SEARCH_CALL_ROOM, callRoomInfoListResponse);
+    }
+
+    @MessageMapping("/offer")
+    @SendTo("/sub/offer")
+    public String handleOffer(String offer) {
+        return offer; // Offer 전달
+    }
+
+    @MessageMapping("/answer/{userId}")
+    @SendTo("/sub/answer/{userId}")
+    public String handleAnswer(@DestinationVariable String userId, String answer) {
+        return answer; // Answer 전달
+    }
+
+    @MessageMapping("/ice-candidate/{userId}")
+    @SendTo("/sub/ice-candidate/{userId}")
+    public String handleIceCandidate(@DestinationVariable String userId, String candidate) {
+        return candidate; // ICE Candidate 전달
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/callroom/controller/CallRoomApiController.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroom/controller/CallRoomApiController.java
@@ -33,21 +33,21 @@ public class CallRoomApiController implements CallRoomApi {
         return Api.success(CallRoomSuccessType.SEARCH_CALL_ROOM, callRoomInfoListResponse);
     }
 
-    @MessageMapping("/offer")
-    @SendTo("/sub/offer")
-    public String handleOffer(String offer) {
+    @MessageMapping("/offer/{roomNumber}")
+    @SendTo("/sub/offer/{roomNumber}")
+    public String handleOffer(@DestinationVariable String roomNumber, String offer) {
         return offer; // Offer 전달
     }
 
-    @MessageMapping("/answer/{userId}")
-    @SendTo("/sub/answer/{userId}")
-    public String handleAnswer(@DestinationVariable String userId, String answer) {
+    @MessageMapping("/answer/{roomNumber}")
+    @SendTo("/sub/answer/{roomNumber}")
+    public String handleAnswer(@DestinationVariable String roomNumber, String answer) {
         return answer; // Answer 전달
     }
 
-    @MessageMapping("/ice-candidate/{userId}")
-    @SendTo("/sub/ice-candidate/{userId}")
-    public String handleIceCandidate(@DestinationVariable String userId, String candidate) {
+    @MessageMapping("/ice-candidate/{roomNumber}")
+    @SendTo("/sub/ice-candidate/{roomNumber}")
+    public String handleIceCandidate(@DestinationVariable String roomNumber, String candidate) {
         return candidate; // ICE Candidate 전달
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/callroom/controller/CallRoomApiController.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroom/controller/CallRoomApiController.java
@@ -33,6 +33,12 @@ public class CallRoomApiController implements CallRoomApi {
         return Api.success(CallRoomSuccessType.SEARCH_CALL_ROOM, callRoomInfoListResponse);
     }
 
+    @MessageMapping("/notice/{roomNumber}")
+    @SendTo("/sub/notice/{roomNumber}")
+    public String handleNotice(@DestinationVariable String roomNumber, String offer) {
+        return offer; // Offer 전달
+    }
+
     @MessageMapping("/offer/{roomNumber}")
     @SendTo("/sub/offer/{roomNumber}")
     public String handleOffer(@DestinationVariable String roomNumber, String offer) {

--- a/src/main/java/org/signaling/signaling_server/domain/callroommember/dto/CallRoomMemberInfoDto.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroommember/dto/CallRoomMemberInfoDto.java
@@ -5,6 +5,7 @@ import org.signaling.signaling_server.entity.friend.enums.FriendStatus;
 
 public record CallRoomMemberInfoDto(
         Long id,
+        Long memberId,
         String nickname,
         CallRoomMemberRole role
 ) {

--- a/src/main/java/org/signaling/signaling_server/domain/callroommember/dto/response/CallRoomMemberInfoResponse.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroommember/dto/response/CallRoomMemberInfoResponse.java
@@ -10,6 +10,7 @@ import org.signaling.signaling_server.entity.callroommember.enums.CallRoomMember
 @Schema(description = "통화방 참여자 정보를 위한 요청")
 public record CallRoomMemberInfoResponse(
         @NotNull @Schema(description = "통화방 참여자 고유 아이디", example = "1") Long callRoomMemberId,
+        @NotNull @Schema(description = "통화방 참여자의 회원 고유 아이디", example = "1") Long memberId,
         @NotBlank @Schema(description = "통화방 참여자 닉네임", example = "홍길동") String nickname,
         @NotBlank @Schema(description = "통화방 참여자 역할", example = "MANAGER") CallRoomMemberRole role
 ) {

--- a/src/main/java/org/signaling/signaling_server/domain/callroommember/mapper/CallRoomMemberResponseMapper.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroommember/mapper/CallRoomMemberResponseMapper.java
@@ -22,6 +22,7 @@ public class CallRoomMemberResponseMapper {
     public static CallRoomMemberInfoResponse toCallRoomMemberInfoResponse(CallRoomMemberInfoDto callRoomMemberInfoDto){
         return CallRoomMemberInfoResponse.builder()
                 .callRoomMemberId(callRoomMemberInfoDto.id())
+                .memberId(callRoomMemberInfoDto.memberId())
                 .nickname(callRoomMemberInfoDto.nickname())
                 .role(callRoomMemberInfoDto.role())
                 .build();

--- a/src/main/java/org/signaling/signaling_server/domain/callroommember/repository/CallRoomMemberRepository.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroommember/repository/CallRoomMemberRepository.java
@@ -24,4 +24,5 @@ public interface CallRoomMemberRepository {
     void deleteById(Long id);
 
     List<CallRoomMemberInfoDto> findByCallRoomId(Long callRoomId);
+    List<CallRoomMemberInfoDto> findByCallRoomIdAndMemberId(Long callRoomId, Long memberId);
 }

--- a/src/main/java/org/signaling/signaling_server/domain/callroommember/repository/CallRoomMemberRepositoryImpl.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroommember/repository/CallRoomMemberRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.signaling.signaling_server.domain.callroommember.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.signaling.signaling_server.domain.callroommember.dto.CallRoomMemberInfoDto;
@@ -68,5 +69,31 @@ public class CallRoomMemberRepositoryImpl implements CallRoomMemberRepository{
                         callRoomMemberEntity.callRoomId.eq(callRoomId) // 특정 call_room_id 조건
                 )
                 .fetch(); // 결과를 리스트로 반환;
+    }
+
+    @Override
+    public List<CallRoomMemberInfoDto> findByCallRoomIdAndMemberId(Long callRoomId, Long memberId) {
+        return jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                CallRoomMemberInfoDto.class,
+                                callRoomMemberEntity.id,     // call_room_member ID
+                                memberEntity.id,             // member ID
+                                memberEntity.nickname,       // 회원 닉네임
+                                callRoomMemberEntity.role    // 회원의 역할
+                        )
+                )
+                .from(callRoomMemberEntity)
+                .leftJoin(memberEntity)
+                .on(callRoomMemberEntity.memberId.eq(memberEntity.id)) // call_room_member와 member 테이블 조인
+                .where(callRoomMemberEntity.callRoomId.eq(callRoomId))  // 특정 call_room_id 조건
+                // memberId를 가진 row를 제일 먼저 오도록 정렬
+                .orderBy(
+                        new CaseBuilder()
+                                .when(callRoomMemberEntity.memberId.eq(memberId)).then(0)
+                                .otherwise(1)
+                                .asc()
+                )
+                .fetch(); // 결과를 리스트로 반환
     }
 }

--- a/src/main/java/org/signaling/signaling_server/domain/callroommember/service/CallRoomMemberService.java
+++ b/src/main/java/org/signaling/signaling_server/domain/callroommember/service/CallRoomMemberService.java
@@ -128,7 +128,7 @@ public class CallRoomMemberService {
             throw new NotFoundException(CallRoomMemberErrorType.NOT_FOUND);
         }
 
-        List<CallRoomMemberInfoDto> callRoomMemberInfoDtoList = callRoomMemberRepository.findByCallRoomId(callRoomId);
+        List<CallRoomMemberInfoDto> callRoomMemberInfoDtoList = callRoomMemberRepository.findByCallRoomIdAndMemberId(callRoomId,userDetail.getId());
 
         List<CallRoomMemberInfoResponse> callRoomMemberInfoResponseList = callRoomMemberInfoDtoList.stream().map(
                 CallRoomMemberResponseMapper::toCallRoomMemberInfoResponse

--- a/src/main/java/org/signaling/signaling_server/domain/friend/service/FriendService.java
+++ b/src/main/java/org/signaling/signaling_server/domain/friend/service/FriendService.java
@@ -36,6 +36,10 @@ public class FriendService {
     public void addFriend(AddFriendRequest addFriendRequest, Authentication authentication) {
         CustomUserDetail userDetails = (CustomUserDetail) authentication.getPrincipal();
 
+        /**TODO 1. email 친구 추가로 변경
+         * 2. 자기 자신 친구 추가 불가
+         * **/
+
         // 친구추가 요청 유무 확인
         if (friendRepository.existsByFromMemberIdAndToMemberIdAndStatus(
                 userDetails.getId(), addFriendRequest.toMemberId(), FriendStatus.REQUEST)) {

--- a/src/main/java/org/signaling/signaling_server/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/org/signaling/signaling_server/domain/member/dto/response/MemberInfoResponse.java
@@ -3,6 +3,7 @@ package org.signaling.signaling_server.domain.member.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 @Schema(description = "회원정보 조회 응답")
 public record MemberInfoResponse(
+        @NotNull @Schema(description = "회원 고유 아이디", example = "1") Long memberId,
         @NotBlank @Schema(description = "아이디", example = "test1234") String username,
         @NotBlank  @Schema(description = "회원이름", example = "최민석") String name,
         @NotBlank @Schema(description = "닉네임", example = "무심천자전거길") String nickname,

--- a/src/main/java/org/signaling/signaling_server/domain/member/mapper/MemberResponseMapper.java
+++ b/src/main/java/org/signaling/signaling_server/domain/member/mapper/MemberResponseMapper.java
@@ -6,6 +6,7 @@ import org.signaling.signaling_server.entity.member.MemberEntity;
 public class MemberResponseMapper {
     public static MemberInfoResponse toMemberResponseMapper(MemberEntity memberEntity){
         return MemberInfoResponse.builder()
+                .memberId(memberEntity.getId())
                 .username(memberEntity.getUsername())
                 .name(memberEntity.getName())
                 .nickname(memberEntity.getNickname())

--- a/src/main/java/org/signaling/signaling_server/filter/JwtRequestFilter.java
+++ b/src/main/java/org/signaling/signaling_server/filter/JwtRequestFilter.java
@@ -58,12 +58,12 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         jwtToken = authorizationHeader.substring(7);
 
         jwtSub = jwtUtils.getSubject(jwtToken);
-        if(uri.contains("/api/auth/refresh-token") && !jwtSub.equals("refreshToken")){
+        if(uri.contains("/api/auth/reissue-token") && !jwtSub.equals("refreshToken")){
             throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
         }
 
         // access token 블랙리스트 확인
-        if (jwtUtils.blackListAccessToken(jwtToken)) {
+        if(jwtUtils.blackListAccessToken(jwtToken) && jwtSub.equals("accessToken")) {
             throw new UnauthorizedException(AuthErrorType.HEADER_INVALID);
         }
 

--- a/src/main/java/org/signaling/signaling_server/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/signaling/signaling_server/handler/GlobalExceptionHandler.java
@@ -26,53 +26,53 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Api<?>> exception(final DataIntegrityViolationException exception) {
         log.error("{}", exception);
-        return new ResponseEntity<>(Api.fail(CommonErrorType.INVALID_BODY), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(Api.fail(CommonErrorType.INVALID_BODY,HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(UnexpectedTypeException.class)
     public ResponseEntity<Api<?>> exception(final UnexpectedTypeException exception) {
         log.error("{}", exception);
-        return new ResponseEntity<>(Api.fail(CommonErrorType.INVALID_TYPE), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(Api.fail(CommonErrorType.INVALID_TYPE, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(NullPointerException.class)
     public ResponseEntity<Api<?>> exception(final NullPointerException exception) {
         log.error("{}", exception);
         return new ResponseEntity<>(
-                Api.fail(CommonErrorType.NULL_POINT), HttpStatus.INTERNAL_SERVER_ERROR);
+                Api.fail(CommonErrorType.NULL_POINT, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<Api<?>> exception(final NoSuchElementException exception) {
         log.error("{}", exception);
         return new ResponseEntity<>(
-                Api.fail(CommonErrorType.NO_SUCH_ELEMENT), HttpStatus.INTERNAL_SERVER_ERROR);
+                Api.fail(CommonErrorType.NO_SUCH_ELEMENT, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(IOException.class)
     public ResponseEntity<Api<?>> exception(final IOException exception) {
         log.error("{}", exception);
-        return new ResponseEntity<>(Api.fail(CommonErrorType.IO), HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(Api.fail(CommonErrorType.IO, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Api<?>> exception(final IllegalArgumentException exception) {
         log.error("{}", exception);
         return new ResponseEntity<>(
-                Api.fail(CommonErrorType.ILLEGAL_ARGUMENT), HttpStatus.INTERNAL_SERVER_ERROR);
+                Api.fail(CommonErrorType.ILLEGAL_ARGUMENT, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Api<?>> handleMethodArgumentNotValidException(
             final MethodArgumentNotValidException exception) {
         return new ResponseEntity<>(
-                Api.fail(CommonErrorType.REQUEST_VALIDATION), HttpStatus.BAD_REQUEST);
+                Api.fail(CommonErrorType.REQUEST_VALIDATION, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Api<?>> exception(final Exception exception) {
         log.error("{}", exception);
         return new ResponseEntity<>(
-                Api.fail(CommonErrorType.INTERNAL_SERVER), HttpStatus.INTERNAL_SERVER_ERROR);
+                Api.fail(CommonErrorType.INTERNAL_SERVER, HttpStatus.INTERNAL_SERVER_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/org/signaling/signaling_server/redis/EmailCodeRepository.java
+++ b/src/main/java/org/signaling/signaling_server/redis/EmailCodeRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface EmailCodeRepository extends CrudRepository<EmailCode, String> {
     Optional<EmailCode> findByEmail(String email);
+
+    void deleteByEmail(String email);
 }


### PR DESCRIPTION
- feat: webRTC signering server 구현
- answer와 offer, ice-candidate로 websocket을 나눠 진행
- notice topic을 통해 회원이 들어왔다는 것을 알림
- A,B,C 클라이언트가 있을 경우
1. A가 들어옴 stomp를 통해 sub/notice/{roomNumber}, /sub/offer/{roomNumber}, /sub/answer/{roomNumber}, /sub/ice-candidate/{roomNumber} 등을 구독.
2. B가 그 뒤에 들어옴 
      - A는 이미 구독 중(/sub/notice/{roomNumber})이므로, B의 notice를 수신함.
      - “notice: 'join', userId: 'B'” 라는 이벤트를 보고, A는 B에게 Offer를 생성/전송한다
      - B는 Offer를 /sub/offer/{roomNumber} 구독으로 수신
      - B가 Answer 생성 → A에게 /pub/answer/{roomNumber}로 전송
      - A는 그 Answer를 받고(handleReceiveAnswer), 서로 ICE Candidate를 교환 → A-B 연결이 형성됨.
3. C가 그 뒤에 들어옴

      - A와 B는 /sub/notice/{roomNumber}를 구독 중이므로, C의 join 메세지를 받는다.

      - A와 B는 C에게 Offer 전송

      - Offer를 받을 때마다 Answer 생성 후 /pub/answer/{roomNumber}로 응답

      - A, B는 각각 C가 보낸 Answer를 받고, ICE Candidate도 교환
4. 3명(A, B, C)이 서로 P2P로 모두 연결 (Mesh)